### PR TITLE
tasks/gce/30-grub: add missing sed trailing slash

### DIFF
--- a/tasks/gce/30-grub
+++ b/tasks/gce/30-grub
@@ -15,5 +15,5 @@ sed -i -e '/GRUB_TIMEOUT=/s/^.*/GRUB_TIMEOUT=0/' $imagedir/etc/default/grub
 # kernel command line.
 sed -i -e '/GRUB_CMDLINE_LINUX=/s/\( \)\?"$/\1console=ttyS0,38400n8"/' \
     $imagedir/etc/default/grub
-sed -i -e '/GRUB_TERMINAL=/s/^.*/GRUB_TERMINAL="serial --unit=0 --speed=38400 --word=8 --parity=no --stop=1"' \
+sed -i -e '/GRUB_TERMINAL=/s/^.*/GRUB_TERMINAL="serial --unit=0 --speed=38400 --word=8 --parity=no --stop=1"/' \
     $imagedir/etc/default/grub

--- a/tasks/gce/30-grub
+++ b/tasks/gce/30-grub
@@ -15,7 +15,3 @@ sed -i -e '/GRUB_TIMEOUT=/s/^.*/GRUB_TIMEOUT=0/' $imagedir/etc/default/grub
 # kernel command line.
 sed -i -e '/GRUB_CMDLINE_LINUX=/s/\( \)\?"$/\1console=ttyS0,38400n8"/' \
     $imagedir/etc/default/grub
-sed -i -e '/GRUB_TERMINAL=/s/^.*/GRUB_TERMINAL="serial"/' \
-    $imagedir/etc/default/grub
-sed -i -e '/GRUB_SERIAL_COMMAND=/s/^.*/GRUB_SERIAL_COMMAND="serial --unit=0 --speed=38400 --word=8 --parity=no --stop=1"/' \
-    $imagedir/etc/default/grub

--- a/tasks/gce/30-grub
+++ b/tasks/gce/30-grub
@@ -15,5 +15,7 @@ sed -i -e '/GRUB_TIMEOUT=/s/^.*/GRUB_TIMEOUT=0/' $imagedir/etc/default/grub
 # kernel command line.
 sed -i -e '/GRUB_CMDLINE_LINUX=/s/\( \)\?"$/\1console=ttyS0,38400n8"/' \
     $imagedir/etc/default/grub
-sed -i -e '/GRUB_TERMINAL=/s/^.*/GRUB_TERMINAL="serial --unit=0 --speed=38400 --word=8 --parity=no --stop=1"/' \
+sed -i -e '/GRUB_TERMINAL=/s/^.*/GRUB_TERMINAL="serial"/' \
+    $imagedir/etc/default/grub
+sed -i -e '/GRUB_SERIAL_COMMAND=/s/^.*/GRUB_SERIAL_COMMAND="serial --unit=0 --speed=38400 --word=8 --parity=no --stop=1"/' \
     $imagedir/etc/default/grub


### PR DESCRIPTION
the sed command is invalid with without the trailing / and will fails, see:

```
proppy@proppy:~$ echo GRUB_TERMINAL= | sed -e '/GRUB_TERMINAL=/s/^.*/GRUB_TERMINAL="serial --unit=0 --speed=38400 --word=8 --parity=no --stop=1"'
sed: -e expression #1, char 97: unterminated `s' command
proppy@proppy:~$ echo GRUB_TERMINAL= | sed -e '/GRUB_TERMINAL=/s/^.*/GRUB_TERMINAL="serial --unit=0 --speed=38400 --word=8 --parity=no --stop=1"/'
GRUB_TERMINAL="serial --unit=0 --speed=38400 --word=8 --parity=no --stop=1"
```
