### PR TITLE
gce: remove deprecated kernel option

### DIFF
--- a/gce
+++ b/gce
@@ -11,7 +11,6 @@ volume_size='10'
 apt_mirrors='http://gce_debian_mirror.storage.googleapis.com/ http://http.debian.net/debian'
 backports_mirrors='http://gce_debian_mirror.storage.googleapis.com/ http://ftp.debian.org/debian'
 use_backports_packages=false
-gce_kernel=projects/google/global/kernels/gce-v20130813
 
 # $description is set later if it has no value yet. This is
 # just for the help output.
@@ -44,7 +43,6 @@ ${txtund}Bootstrapping${txtdef}
 ${txtund}GCE${txtdef}
     --gcs-dest URL                Google Cloud Storage image destination URL prefix (${txtbld}${gcs_dest}${txtdef})
     --gce-project PROJECT         Google Compute Engine image destination project (${txtbld}${gce_project}${txtdef})
-    --gce-kernel KERNEL           Google Compute Engine image kernel (${txtbld}${gce_kernel}${txtdef})
 
 ${txtund}Other options${txtdef}
     --debug                       Print debugging information

--- a/tasks/gce/95-register-image
+++ b/tasks/gce/95-register-image
@@ -27,5 +27,4 @@ fi
 
 log "Adding image \"${image_name}\" to GCE project \"${gce_project}\""
 gcutil --project="${gce_project}" addimage "${image_name}" \
-  "${gcs_dest}/${tarball_name}" --description="${description}" \
-  --preferred_kernel="${gce_kernel}"
+  "${gcs_dest}/${tarball_name}" --description="${description}"


### PR DESCRIPTION
remove the deprecated --preferred_kernel option.

w/o this patch I get the following error:

```
Apr 28 21:08:16 build-debian-cloud-ci startupscript: UnsupportedCommand: --preferred_kernel is deprecated in v1. You may still specify a preferred kernel by using --service_version=v1beta16
```
