### PR TITLE
Instal cloud sdk as a tar ball on images

### DIFF
--- a/tasks/gce/25-install-cloudsdk
+++ b/tasks/gce/25-install-cloudsdk
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+wget -O $imagedir/tmp/google-cloud-sdk-coretools-linux-x86_64.tar.gz https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk-coretools-linux-x86_64.tar.gz
+
+mkdir -p $imagedir/usr/local/share/google
+tar xf $imagedir/tmp/google-cloud-sdk-coretools-linux-x86_64.tar.gz -C $imagedir/usr/local/share/google
+ln -s ../share/google/google-cloud-sdk/bin/gsutil $imagedir/usr/local/bin/gsutil
+ln -s ../share/google/google-cloud-sdk/bin/gcutil $imagedir/usr/local/bin/gcutil
+ln -s ../share/google/google-cloud-sdk/bin/gcloud $imagedir/usr/local/bin/gcloud

--- a/tasks/gce/25-install-gce-debs
+++ b/tasks/gce/25-install-gce-debs
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Add GCE startup scripts and packages to the image.
 
-DEBS="google-compute-daemon google-startup-scripts python-gcimagebundle gcutil"
+DEBS="google-compute-daemon google-startup-scripts python-gcimagebundle"
 for deb in $DEBS; do
   chroot $imagedir apt-get install --force-yes -q -y ${deb}
 done

--- a/tasks/gce/25-install-gsutil
+++ b/tasks/gce/25-install-gsutil
@@ -1,7 +1,0 @@
-#! /bin/bash
-
-wget -O $imagedir/tmp/gsutil.tar.gz http://storage.googleapis.com/pub/gsutil.tar.gz
-
-mkdir -p $imagedir/usr/local/share/google
-tar xf $imagedir/tmp/gsutil.tar.gz -C $imagedir/usr/local/share/google
-ln -s ../share/google/gsutil/gsutil $imagedir/usr/local/bin/gsutil


### PR DESCRIPTION
Removing separate gcutil and gsutil install since they are part of cloud sdk.
Working on updating bootstrap-vz code and submitting a pull request separately.
